### PR TITLE
Add support for path prefix matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See the [examples](https://github.com/BTBurke/caddy-extauth/tree/master/examples
 
 ### Advanced Syntax
 
-You can optionally turn off headers, cookies, set a timeout, and skip TLS verification (for example, if you are using a self-signed cert):
+You can optionally turn off headers, cookies, set a timeout, skip TLS verification (for example, if you are using a self-signed cert), and only check requests to certain path prefixes:
 
 ```
 extauth {
@@ -66,5 +66,6 @@ extauth {
   headers false
   timeout 30s
   insecure_skip_verify true  
+  prefixes /api /private
 }
 ```

--- a/config.go
+++ b/config.go
@@ -19,6 +19,7 @@ type Auth struct {
 	Timeout            time.Duration
 	InsecureSkipVerify bool
 	Router             bool
+	Prefixes           []string
 	Next               httpserver.Handler
 
 	client *http.Client
@@ -51,6 +52,7 @@ func Setup(c *caddy.Controller) error {
 			Timeout:            auth.Timeout,
 			InsecureSkipVerify: auth.InsecureSkipVerify,
 			Router:             auth.Router,
+			Prefixes:           auth.Prefixes,
 			Next:               next,
 		}
 	})
@@ -112,6 +114,13 @@ func parse(c *caddy.Controller) (*Auth, error) {
 					}
 				case "insecure_skip_verify":
 					def.InsecureSkipVerify = true
+				case "prefixes":
+					for c.NextArg() {
+						def.Prefixes = append(def.Prefixes, c.Val())
+					}
+					if len(def.Prefixes) == 0 {
+						return nil, c.ArgErr()
+					}
 				case "timeout":
 					if !c.NextArg() {
 						return nil, c.ArgErr()

--- a/config_test.go
+++ b/config_test.go
@@ -26,14 +26,46 @@ func TestParsing(t *testing.T) {
 		shouldErr bool
 		expect    Auth
 	}{
-		{"extauth https://testserver:9000", false, Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)}},
-		{"extauth {\nproxy https://testserver:9000\n}", false, Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)}},
-		{"extauth {\nproxy testserver:9000\n}", false, Auth{Proxy: "http://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)}},
-		{"extauth", true, Auth{}},
-		{"extauth {\nproxy https://testserver:9000\nprefixes /api /private\n}", false, Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second), Prefixes: []string{"/api", "/private"}}},
-		{"extauth {\nproxy https://testserver:9000\nprefixes\n}", true, Auth{}},
-		{"extauth {\nproxy https://testserver:9000\ncookies false\nheaders false\n}", false, Auth{Proxy: "https://testserver:9000", Headers: false, Cookies: false, Timeout: time.Duration(30 * time.Second)}},
-		{"extauth {\nproxy https://testserver:9000\ncookies false\nheaders false\ntimeout 60s\ninsecure_skip_verify\nrouter\n}", false, Auth{Proxy: "https://testserver:9000", Router: true, Headers: false, Cookies: false, Timeout: time.Duration(60 * time.Second), InsecureSkipVerify: true}},
+		{
+			"extauth",
+			true,
+			Auth{},
+		},
+		{
+			"extauth {\nproxy https://testserver:9000\nprefixes\n}",
+			true,
+			Auth{},
+		},
+		{
+			"extauth https://testserver:9000",
+			false,
+			Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)},
+		},
+		{
+			"extauth {\nproxy https://testserver:9000\n}",
+			false,
+			Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)},
+		},
+		{
+			"extauth {\nproxy testserver:9000\n}",
+			false,
+			Auth{Proxy: "http://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)},
+		},
+		{
+			"extauth {\nproxy https://testserver:9000\nprefixes /api /private\n}",
+			false,
+			Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second), Prefixes: []string{"/api", "/private"}},
+		},
+		{
+			"extauth {\nproxy https://testserver:9000\ncookies false\nheaders false\n}",
+			false,
+			Auth{Proxy: "https://testserver:9000", Headers: false, Cookies: false, Timeout: time.Duration(30 * time.Second)},
+		},
+		{
+			"extauth {\nproxy https://testserver:9000\ncookies false\nheaders false\ntimeout 60s\ninsecure_skip_verify\nrouter\n}",
+			false,
+			Auth{Proxy: "https://testserver:9000", Router: true, Headers: false, Cookies: false, Timeout: time.Duration(60 * time.Second), InsecureSkipVerify: true},
+		},
 	}
 	for _, test := range tests {
 		c := caddy.NewTestController("http", test.input)

--- a/config_test.go
+++ b/config_test.go
@@ -30,6 +30,8 @@ func TestParsing(t *testing.T) {
 		{"extauth {\nproxy https://testserver:9000\n}", false, Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)}},
 		{"extauth {\nproxy testserver:9000\n}", false, Auth{Proxy: "http://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second)}},
 		{"extauth", true, Auth{}},
+		{"extauth {\nproxy https://testserver:9000\nprefixes /api /private\n}", false, Auth{Proxy: "https://testserver:9000", Headers: true, Cookies: true, Timeout: time.Duration(30 * time.Second), Prefixes: []string{"/api", "/private"}}},
+		{"extauth {\nproxy https://testserver:9000\nprefixes\n}", true, Auth{}},
 		{"extauth {\nproxy https://testserver:9000\ncookies false\nheaders false\n}", false, Auth{Proxy: "https://testserver:9000", Headers: false, Cookies: false, Timeout: time.Duration(30 * time.Second)}},
 		{"extauth {\nproxy https://testserver:9000\ncookies false\nheaders false\ntimeout 60s\ninsecure_skip_verify\nrouter\n}", false, Auth{Proxy: "https://testserver:9000", Router: true, Headers: false, Cookies: false, Timeout: time.Duration(60 * time.Second), InsecureSkipVerify: true}},
 	}
@@ -43,6 +45,7 @@ func TestParsing(t *testing.T) {
 			assert.Equal(t, test.expect.Proxy, actual.Proxy)
 			assert.Equal(t, test.expect.Cookies, actual.Cookies)
 			assert.Equal(t, test.expect.Headers, actual.Headers)
+			assert.Equal(t, test.expect.Prefixes, actual.Prefixes)
 		}
 	}
 }

--- a/extauth.go
+++ b/extauth.go
@@ -5,9 +5,23 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 func (a *Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
+	// Before anything else, see if we need to check this request and short circuit if not.
+	if len(a.Prefixes) != 0 {
+		skipAuthorization := true
+		for _, prefix := range a.Prefixes {
+			if strings.HasPrefix(r.URL.Path, prefix) {
+				skipAuthorization = false
+				break
+			}
+		}
+		if skipAuthorization {
+			return a.Next.ServeHTTP(w, r)
+		}
+	}
 
 	// create client if it doesn't exist, in normal operation client should be nil
 	// but having the client as part of the auth struct is useful for testing


### PR DESCRIPTION
Adds support for limiting the path prefixes to check. This is particularly helpful for combined static and API proxy servers where the static assets aren't sensitive.

The `config_test.go` change got a bit larger in the second commit, but other than adding two prefix test cases (in the first commit), should be the same.